### PR TITLE
ci: update runner vm and node version

### DIFF
--- a/.github/workflows/quality-gate.yml
+++ b/.github/workflows/quality-gate.yml
@@ -7,14 +7,14 @@ on:
 jobs:
     quality-gate:
         name: Check code
-        runs-on: ubuntu-20.04
+        runs-on: ubuntu-24.04
         steps:
             - name: Checkout
               uses: actions/checkout@v2.3.1
             - name: Setup Node.js
               uses: actions/setup-node@v2
               with:
-                  node-version: "18"
+                  node-version: "22"
             - name: Install dependencies
               run: npm ci --fund=false --audit=false --legacy-peer-deps
             - name: Unit tests


### PR DESCRIPTION
A github action nem működött, mert a runner VM-t kivezették, a Node.js verziót is updateltem.